### PR TITLE
chore: fix `must_use` attribute syntax

### DIFF
--- a/async_ui_web_html/src/common_events.rs
+++ b/async_ui_web_html/src/common_events.rs
@@ -3,7 +3,7 @@ use web_sys::{Element, HtmlElement};
 
 macro_rules! make_event_impl {
     ($ev_name:literal, $func_name:ident, $ty:ty, $link:tt) => {
-        #[must_use("the returned object is a Future+Stream that does nothing unless polled")]
+        #[must_use = "the returned object is a Future+Stream that does nothing unless polled"]
         #[doc = "Like [until_event][EmitEvent::until_event] for the `"]
         #[doc = $ev_name]
         #[doc = "` event."]


### PR DESCRIPTION
This worked previously because the compiler did not check attributes in traits, see https://github.com/rust-lang/rust/pull/121545