### PR TITLE
Silence some deprecation warnings

### DIFF
--- a/async_ui_web/src/lists/virtualized_list.rs
+++ b/async_ui_web/src/lists/virtualized_list.rs
@@ -235,11 +235,13 @@ struct Observer {
 
 impl Observer {
     fn new(root: &Element, spacers: &[&HtmlElement], wake: &js_sys::Function) -> Self {
+        let options = IntersectionObserverInit::new();
+        options.set_root(Some(root));
+        options.set_root_margin("100%");
+
         let observer = IntersectionObserver::new_with_options(
             wake,
-            IntersectionObserverInit::new()
-                .root(Some(root))
-                .root_margin("100%"),
+            &options
         )
         .unwrap_throw();
         spacers.iter().for_each(|sp| observer.observe(sp));

--- a/async_ui_web_html/src/event_handling.rs
+++ b/async_ui_web_html/src/event_handling.rs
@@ -55,7 +55,7 @@ impl<E: JsCast> EventFutureStream<E> {
     pub fn set_capture(&mut self, capture: bool) {
         self.options
             .get_or_insert_with(AddEventListenerOptions::new)
-            .capture(capture);
+            .set_capture(capture);
     }
     /// The `passive` option indicates that the function specified by listener
     /// will never call `preventDefault()`.
@@ -70,7 +70,7 @@ impl<E: JsCast> EventFutureStream<E> {
     pub fn set_passive(&mut self, passive: bool) {
         self.options
             .get_or_insert_with(AddEventListenerOptions::new)
-            .passive(passive);
+            .set_passive(passive);
     }
 }
 


### PR DESCRIPTION
A few APIs have changed in `web-sys`. This resolves some deprecation warnings.