### PR TITLE
Render custom element

### DIFF
--- a/async_ui_web_html/src/common_components.rs
+++ b/async_ui_web_html/src/common_components.rs
@@ -159,11 +159,16 @@ pub use impls::*;
 pub struct CustomElement {
     pub element: web_sys::HtmlElement,
 }
+
 impl CustomElement {
     pub fn new(tag_name: Cow<'static, str>) -> Self {
         Self {
             element: create_element(&tag_name),
         }
+    }
+
+    pub fn render<F: Future>(&self, c: F) -> ContainerNodeFuture<F> {
+        ContainerNodeFuture::new(c, AsRef::<web_sys::Node>::as_ref(&self.element).clone())
     }
 }
 


### PR DESCRIPTION
It seemed that `html::CustomElement` was missing a render function. I'm making use of HTML [templates with slots](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots) and custom elements so I needed this function.

I'm not sure if this is the preferred way to implement this, but happy to adjust as needed.